### PR TITLE
Correcting an error in application.properties and adding spring-boot-…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
 		</dependency>
-
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-web</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.jpa.hibernate.ddl-auto=update
-spring.datasource.url = jdbc:h2:mem:testdb:DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.url = jdbc:h2:mem:testdb;DB_CLOSE_ON_EXIT=FALSE
 
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.generate_statistics=false


### PR DESCRIPTION
application.properties

The application.properties had an typo in spring.datasource.url property. After "testdb" a colon was present and due to this the h2 database was not being created. Changed this to a semicolon.

spring.datasource.url = jdbc:h2:mem:testdb;DB_CLOSE_ON_EXIT=FALSE

pom.xml

The application was stopping with the following error message as soon as it was started:

`Process finished with exit code 0
`
Added the spring-boot-starter-web dependency to prevent this from happening.